### PR TITLE
Additional Light Settings

### DIFF
--- a/gui/environmentSettingsPage.xml
+++ b/gui/environmentSettingsPage.xml
@@ -27,6 +27,22 @@
 					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
 					<GuiElement type="bitmap" profile="baseReference" position="730px 0px" size="50px 50px"/>
 				</GuiElement>
+				<GuiElement type="multiTextOption" profile="multiTextOptionSettings" onCreate="onCreateAutoDriveSetting" onClick="onOptionChange" name="useWorkLightsLoading" toolTipElementId="ingameMenuHelpBoxText">
+					<GuiElement type="button" profile="multiTextOptionSettingsLeft" />
+					<GuiElement type="button" profile="multiTextOptionSettingsRight" />
+					<GuiElement type="text" profile="multiTextOptionSettingsText" />
+					<GuiElement type="text" profile="multiTextOptionSettingsTitle" position="27px 0px" />
+					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
+					<GuiElement type="bitmap" profile="baseReference" position="730px 0px" size="50px 50px"/>
+				</GuiElement>
+				<GuiElement type="multiTextOption" profile="multiTextOptionSettings" onCreate="onCreateAutoDriveSetting" onClick="onOptionChange" name="useWorkLightsSilo" toolTipElementId="ingameMenuHelpBoxText">
+					<GuiElement type="button" profile="multiTextOptionSettingsLeft" />
+					<GuiElement type="button" profile="multiTextOptionSettingsRight" />
+					<GuiElement type="text" profile="multiTextOptionSettingsText" />
+					<GuiElement type="text" profile="multiTextOptionSettingsTitle" position="27px 0px" />
+					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
+					<GuiElement type="bitmap" profile="baseReference" position="730px 0px" size="50px 50px"/>
+				</GuiElement>
 			</GuiElement>
 		</GuiElement>
 

--- a/scripts/Settings.lua
+++ b/scripts/Settings.lua
@@ -751,6 +751,29 @@ AutoDrive.settings.useBeaconLights = {
     isVehicleSpecific = true
 }
 
+AutoDrive.settings.useWorkLightsLoading = {
+    values = {false, true},
+    texts = {"gui_ad_no", "gui_ad_yes"},
+    default = 2,
+    current = 2,
+    text = "gui_ad_worklightsWhenLoading",
+    tooltip = "gui_ad_worklightsWhenLoading_tooltip",
+    translate = true,
+    isVehicleSpecific = true
+}
+
+AutoDrive.settings.useWorkLightsSilo = {
+    values = {false, true},
+    texts = {"gui_ad_no", "gui_ad_yes"},
+    default = 2,
+    current = 2,
+    text = "gui_ad_worklightsWhenSilo",
+    tooltip = "gui_ad_worklightsWhenSilo_tooltip",
+    translate = true,
+    isVehicleSpecific = true
+}
+
+
 AutoDrive.settings.activeUnloading = {
     values = {false, true},
     texts = {"gui_ad_no", "gui_ad_yes"},

--- a/scripts/Specialization.lua
+++ b/scripts/Specialization.lua
@@ -1455,29 +1455,11 @@ end
 
 function AutoDrive:updateAutoDriveLights()
     if self.ad ~= nil and self.ad.stateModule:isActive() then
-        -- If AutoDrive is active, then we take care of lights our self
-        local spec = self.spec_lights
-        local dayMinutes = g_currentMission.environment.dayTime / (1000 * 60)
-        local needLights = not g_currentMission.environment.isSunOn -- (dayMinutes > g_currentMission.environment.nightStartMinutes or dayMinutes < g_currentMission.environment.nightEndMinutes)
-        if needLights then
-            local x, y, z = getWorldTranslation(self.components[1].node)            
-            if spec.aiLightsTypesMaskWork ~= nil and spec.lightsTypesMask ~= spec.aiLightsTypesMaskWork and AutoDrive.checkIsOnField(x, y, z) then
-                self:setLightsTypesMask(spec.aiLightsTypesMaskWork)
-                return
-            end
-            
-            if spec.aiLightsTypesMask ~= nil and spec.lightsTypesMask ~= spec.aiLightsTypesMask and not AutoDrive.checkIsOnField(x, y, z) then
-                self:setLightsTypesMask(spec.aiLightsTypesMask)
-                return
-            end
+        local isInRangeToLoadUnloadTarget = AutoDrive.isInRangeToLoadUnloadTarget(self)
+        local isOnField = ( self.getIsOnField ~= nil and self:getIsOnField() )
 
-            if spec.lightsTypesMask ~= 1 and not AutoDrive.checkIsOnField(x, y, z) then
-                self:setLightsTypesMask(1)
-            end
-        else
-            if spec.lightsTypesMask ~= 0 then
-                self:setLightsTypesMask(0)
-            end
+        if self.updateAILights ~= nil then
+            self:updateAILights(isOnField or isInRangeToLoadUnloadTarget)
         end
     end
 end

--- a/scripts/Specialization.lua
+++ b/scripts/Specialization.lua
@@ -1455,11 +1455,20 @@ end
 
 function AutoDrive:updateAutoDriveLights()
     if self.ad ~= nil and self.ad.stateModule:isActive() then
-        local isInRangeToLoadUnloadTarget = AutoDrive.isInRangeToLoadUnloadTarget(self)
-        local isOnField = ( self.getIsOnField ~= nil and self:getIsOnField() )
+        local isInRangeToLoadUnloadTarget = false
+        local isInBunkerSilo              = false
+        local isOnField                   = ( self.getIsOnField ~= nil and self:getIsOnField() )
+
+        if AutoDrive.getSetting("useWorkLightsLoading", self) then
+            isInRangeToLoadUnloadTarget = AutoDrive.isInRangeToLoadUnloadTarget(self)
+        end
+
+        if AutoDrive.getSetting("useWorkLightsSilo", self) then
+            isInBunkerSilo = AutoDrive.isVehicleInBunkerSiloArea(self)
+        end
 
         if self.updateAILights ~= nil then
-            self:updateAILights(isOnField or isInRangeToLoadUnloadTarget)
+            self:updateAILights(isOnField or isInRangeToLoadUnloadTarget or isInBunkerSilo)
         end
     end
 end

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -163,6 +163,10 @@
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Bis zu dieser Entfernung zum Zielpunkt wird beladen/entladen bei erkanntem Trigger." />
 		<text name="gui_ad_useBeaconLights"						text="Rundumleuchten" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Ja - Außerhalb des Felds automatisch eingeschaltet / Nein - Rundumleuchten werden nicht automatisch ein- oder ausgeschaltet" />
+		<text name="gui_ad_worklightsWhenLoading"				text="Arbeitsscheinwerfer beim Be- und Entladen" />
+		<text name="gui_ad_worklightsWhenLoading_tooltip"		text="Ja - Benutzen Sie beim Be- und Entladen an einem Auslöser Arbeitsscheinwerfer." />
+		<text name="gui_ad_worklightsWhenSilo"					text="Arbeitsscheinwerfer in einem Silobunker" />
+		<text name="gui_ad_worklightsWhenSilo_tooltip"			text="Ja - Benutzen Sie Arbeitsscheinwerfer, wenn Sie sich in einem Silobunker aufhalten." />
 		<text name="gui_ad_activeUnloading"						text="Aktives Abfahren" />
 		<text name="gui_ad_activeUnloading_tooltip"				text="Ernter während der Fahrt abfahren" />
 		<text name="gui_ad_restrictToField"						text="Pfadplanung begrenzt" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -163,6 +163,10 @@
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distance to target at which triggers are detected and activated." />
 		<text name="gui_ad_useBeaconLights"						text="Beacon lights" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Yes - Use beacon lights automatic outside of fields / No - beacon lights will not be turned on or off automatically" />
+		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />
+		<text name="gui_ad_worklightsWhenLoading_tooltip"		text="Yes - Use working lights when loading or unloading at a trigger" />
+		<text name="gui_ad_worklightsWhenSilo"					text="Worklight when in a Silo Bunker" />
+		<text name="gui_ad_worklightsWhenSilo_tooltip"			text="Yes - Use working lights when in a silo bunker" />
 		<text name="gui_ad_activeUnloading"						text="Active unloading" />
 		<text name="gui_ad_activeUnloading_tooltip"				text="Unload harvesters while driving." />
 		<text name="gui_ad_restrictToField"						text="Restrict pathfinder to field" />


### PR DESCRIPTION
So, in keeping with our discussion during the fs19 days, I tried to keep this as barebones as I possibly could, and used the new settings page that was created with these sorts of things in mind.

Adding 2 settings
 - Turn on work lights (aiLightsTypesMaskWork) when nearing a load / unload trigger
 - Turn on work lights (aiLightsTypesMaskWork) when in a silo bunker

Re-worked the base light code so it's calling the base game function instead of recreating it - somewhat for selfish reasons, as this lets my mod `Better AI Lights` override when lights are on (it turns them on for rain and snow), but my thought was if other mods appear that mess with lights, this will let AutoDrive play nicely with them moving forward - it may be worth noting that this is how the CoursePlay folks handled it this time too.

Thanks for all you do - great work!