### PR TITLE
Update AutoDriveUtilFuncs.lua

### DIFF
--- a/scripts/Utils/AutoDriveUtilFuncs.lua
+++ b/scripts/Utils/AutoDriveUtilFuncs.lua
@@ -620,7 +620,7 @@ function AutoDrive.isImplementAllowedForReverseDriving(vehicle,implement)
         end
     end
 
-    if implement ~= nil and implement.spec_attachable ~= nil 
+    if implement ~= nil and implement.spec_attachable ~= nil and implement.spec_attachable.attacherJoint ~= nil and implement.spec_attachable.attacherJoint.jointType ~= nil
         and AttacherJoints.JOINTTYPE_IMPLEMENT == implement.spec_attachable.attacherJoint.jointType 
     then
         local breakforce = implement.spec_attachable:getBrakeForce()
@@ -632,7 +632,7 @@ function AutoDrive.isImplementAllowedForReverseDriving(vehicle,implement)
         end
     end
 
-    if implement ~= nil and implement.spec_attachable ~= nil 
+    if implement ~= nil and implement.spec_attachable ~= nil and implement.spec_attachable.attacherJoint ~= nil and implement.spec_attachable.attacherJoint.jointType ~= nil
         and AttacherJoints.JOINTTYPE_SEMITRAILER == implement.spec_attachable.attacherJoint.jointType 
     then
         local implementX, implementY, implementZ = getWorldTranslation(implement.components[1].node)


### PR DESCRIPTION
Null ref crash fix when implement.spec_attachable is nil or implement.spec_attachable.attacherJoint is nil.

I keep hitting this error after a couple of hours of play (and unable to repeat reliably to narrow down the equipment in use at the time).