### PR TITLE
Fix for Pumps N' Hoses DLC

### DIFF
--- a/scripts/Hud.lua
+++ b/scripts/Hud.lua
@@ -139,8 +139,8 @@ function AutoDriveHud:createHudAt(hudX, hudY)
 	self.gapWidth, self.gapHeight = getNormalizedScreenValues(uiScale * gapSize, uiScale * gapSize)
 	self.iconWidth, self.iconHeight = getNormalizedScreenValues(uiScale * iconSize, uiScale * iconSize)
 	self.listItemWidth, self.listItemHeight = getNormalizedScreenValues(uiScale * listItemSize, uiScale * listItemSize)
-	self.posX = math.clamp(0, hudX, 1 - self.width)
-	self.posY = math.clamp(2 * self.gapHeight, hudY, 1 - (self.height + 3 * self.gapHeight + self.headerHeight))
+	self.posX = math.clamp(hudX, 0 , 1 - self.width)
+	self.posY = math.clamp(hudY, 2 * self.gapHeight,  1 - (self.height + 3 * self.gapHeight + self.headerHeight))
 
 
 	AutoDrive.HudX = self.posX

--- a/scripts/Modules/DrivePathModule.lua
+++ b/scripts/Modules/DrivePathModule.lua
@@ -241,7 +241,7 @@ function ADDrivePathModule:followWaypoints(dt)
             local currentTask = self.vehicle.ad.taskModule:getActiveTask()
             local isCatchingCombine = currentTask.taskType ~= nil and self.vehicle.ad.taskModule:getActiveTask().taskType == "CatchCombinePipeTask"
             if not isCatchingCombine then
-                self.speedLimit = math.clamp(8, self.speedLimit, 2 + self.distanceToTarget)
+                self.speedLimit = math.clamp(self.speedLimit, 8, 2 + self.distanceToTarget)
             end
         end
 
@@ -394,7 +394,7 @@ function ADDrivePathModule:getHighestApproachingAngle()
             
             AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_DEVINFO, "ADDrivePathModule:getHighestApproachingAngle -> angle: " .. angle)
 
-            self.turnAngle = self.turnAngle + math.clamp(-90, angle, 90)
+            self.turnAngle = self.turnAngle + math.clamp(angle, -90, 90)
 
             angle = math.abs(angle)
 
@@ -486,7 +486,7 @@ function ADDrivePathModule:getMaxSpeedForAngle(angle)
     if angle < 5 then
         maxSpeed = math.huge
     elseif angle < 50 then
-        maxSpeed = 12 + 48 * (1 - math.clamp(0, (angle - 5), 25) / (30 - 5))
+        maxSpeed = 12 + 48 * (1 - math.clamp((angle - 5), 0, 25) / (30 - 5))
     elseif angle >= 50 then
         maxSpeed = 3
     end

--- a/scripts/Modules/SpecialDrivingModule.lua
+++ b/scripts/Modules/SpecialDrivingModule.lua
@@ -422,7 +422,7 @@ function ADSpecialDrivingModule:reverseToPoint(dt, maxSpeed)
         self.dFactor = 6.7 --self.vehicle.ad.stateModule:getFieldSpeedLimit() * 0.1 --10
     end
 
-    local targetAngleToTrailer = math.clamp(-40, (p * self.pFactor) + (self.i * self.iFactor) + (d * self.dFactor), 40)
+    local targetAngleToTrailer = math.clamp((p * self.pFactor) + (self.i * self.iFactor) + (d * self.dFactor), -40, 40)
     local targetDiff = self.angleToTrailer - targetAngleToTrailer
     local offsetX = -targetDiff * 5
     local offsetZ = -20
@@ -436,7 +436,7 @@ function ADSpecialDrivingModule:reverseToPoint(dt, maxSpeed)
     --print("p: " .. p * self.pFactor .. " i: " .. (self.i * self.iFactor) .. " d: " .. (d * self.dFactor))
     --print("targetAngleToTrailer: " .. targetAngleToTrailer .. " targetDiff: " .. targetDiff .. "  offsetX" .. offsetX)
 
-    local speed = 5 + (6 * math.clamp(0, (5 / math.max(self.steeringAngle, math.abs(self.angleToTrailer))), 1))
+    local speed = 5 + (6 * math.clamp((5 / math.max(self.steeringAngle, math.abs(self.angleToTrailer))), 0, 1))
     local acc = 0.4
 
     if vehicleIsTruck then

--- a/scripts/Sensors/VirtualSensors.lua
+++ b/scripts/Sensors/VirtualSensors.lua
@@ -268,9 +268,9 @@ function ADSensor:getBoxShape()
     self.location = self:getLocationByPosition()
     local lookAheadDistance = self.length
     if self.dynamicLength then
-        lookAheadDistance = math.clamp(0.13, vehicle.lastSpeedReal * 3600 / 40, 1) * 15.5
+        lookAheadDistance = math.clamp(vehicle.lastSpeedReal * 3600 / 40, 0.13, 1) * 15.5
         if self.position == ADSensor.POS_REAR then
-            lookAheadDistance = math.clamp(0.02, vehicle.lastSpeedReal * 3600 / 40, 1) * 15.5
+            lookAheadDistance = math.clamp(vehicle.lastSpeedReal * 3600 / 40, 0.02, 1) * 15.5
         end
     end
 

--- a/scripts/Utils/UtilFuncs.lua
+++ b/scripts/Utils/UtilFuncs.lua
@@ -162,11 +162,14 @@ function AutoDrive.boxesIntersect(a, b)
 	return true
 end
 
-function math.clamp(minValue, value, maxValue)
-	if minValue ~= nil and value ~= nil and maxValue ~= nil then
-		return math.max(minValue, math.min(maxValue, value))
+-- Pumps N' Hoses DLC provides this function, we reuse their function if defined.
+if math.clamp == nil then
+	function math.clamp(value, minValue, maxValue)
+		if minValue ~= nil and value ~= nil and maxValue ~= nil then
+			return math.max(minValue, math.min(maxValue, value))
+		end
+		return value
 	end
-	return value
 end
 
 function table:contains(value)
@@ -721,7 +724,7 @@ end
 function ADVectorUtils.linterp(inMin, inMax, inValue, outMin, outMax)
 	-- normalize input, make min range boundary = 0, nval is between 0..1
 	local imax = inMax - inMin
-	local nval = math.clamp(0, inValue - inMin, imax) / imax
+	local nval = math.clamp(inValue - inMin, 0, imax) / imax
 	-- normalize output
 	local omax = outMax - outMin
 	local oval = outMin + ( omax * nval )
@@ -949,7 +952,7 @@ end
 
 function AutoDrive:zoomSmoothly(superFunc, offset)
 	if AutoDrive.splineInterpolation ~= nil and AutoDrive.splineInterpolation.valid then
-		AutoDrive.splineInterpolationUserCurvature = math.clamp(0.49, AutoDrive.splineInterpolationUserCurvature + offset/12  ,3.5)
+		AutoDrive.splineInterpolationUserCurvature = math.clamp(AutoDrive.splineInterpolationUserCurvature + offset/12, 0.49, 3.5)
 		return
 	end
 	if not AutoDrive.mouseWheelActive then -- don't zoom camera when mouse wheel is used to scroll targets (thanks to sperrgebiet)


### PR DESCRIPTION
PnH defines also a math.clamp function, but the parameter order is different. So I adjusted the order of the AutoDrive function to match the one of pnh. 

Fixes #697 

Fixes the following two issues
- Autodrive: Pulling arm of ToolCarrier gets separated and rotation is blocked
- Autodrive: Hoses seem to be "stretched" and cannot be reeled after some time if the hose length is theoretically 100% of the reels capacity

[FS22_AutoDrive.zip](https://github.com/Stephan-S/FS22_AutoDrive/files/9690674/FS22_AutoDrive.zip)
