### PR TITLE
Issue #990

### DIFF
--- a/scripts/Modules/StateModule.lua
+++ b/scripts/Modules/StateModule.lua
@@ -858,6 +858,10 @@ function ADStateModule:toggleFillTypeSelection(fillType)
             end
         else
             table.insert(self.selectedFillTypes, fillType)
+            if not table.contains(self.selectedFillTypes, self.fillType) then
+                -- selectedFillTypes was empty, select the new fillType
+                self.fillType = fillType
+            end
         end
         self:raiseDirtyFlag()
     end
@@ -910,7 +914,7 @@ function ADStateModule:selectPreferredFillTypeFromFillLevels(fillLevels)
     end
     table.sort(fillLevelList)  -- sort it
     local requiredFillLevel = fillLevelList[#fillLevelList]
-    local idx = table.indexOf(self.selectedFillTypes, self.fillType)  -- starting point
+    local idx = table.indexOf(self.selectedFillTypes, self.fillType) or 0 -- starting point
     local loopsLeft = #self.selectedFillTypes
     local pickNextNonEmpty = requiredFillLevel == -1 or not self.loadByFillLevel
     if idx == nil or requiredFillLevel == nil then


### PR DESCRIPTION
- select current filltype when adding first entry to multi-selection
- ensure a valid index when looping over filltypes
@Axel32019 - the first one is the proper fix, the second one is just-to-be-safe 