### PR TITLE
#962 #858 #204 - Optionally, set a vehicle specific maximum trigger distance

### DIFF
--- a/gui/vehicleSettingsPage.xml
+++ b/gui/vehicleSettingsPage.xml
@@ -163,6 +163,14 @@
 					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
 					<GuiElement type="bitmap" profile="baseReference" position="730px 0px" size="50px 50px"/>
 				</GuiElement> 
+				<GuiElement type="multiTextOption" profile="multiTextOptionSettings" onCreate="onCreateAutoDriveSetting" onClick="onOptionChange" name="maxTriggerDistanceVehicle" toolTipElementId="ingameMenuHelpBoxText">
+					<GuiElement type="button" profile="multiTextOptionSettingsLeft" />
+					<GuiElement type="button" profile="multiTextOptionSettingsRight" />
+					<GuiElement type="text" profile="multiTextOptionSettingsText" />
+					<GuiElement type="text" profile="multiTextOptionSettingsTitle" position="27px 0px" />
+					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
+					<GuiElement type="bitmap" profile="baseReference" position="730px 0px" size="50px 50px"/>
+				</GuiElement>
 			</GuiElement>
 		</GuiElement>
 		<GuiElement type="bitmap" profile="ingameMenuHelpRowBg" position="210px -64px" id="ingameMenuHelpBox" visible="false">

--- a/scripts/Modules/DrivePathModule.lua
+++ b/scripts/Modules/DrivePathModule.lua
@@ -269,12 +269,12 @@ function ADDrivePathModule:followWaypoints(dt)
             self.speedLimit = math.min(self.vehicle.ad.trailerModule:getBunkerSiloSpeed(), self.speedLimit)
             maxSpeedDiff = 1
         else
-            if self.distanceToTarget < (AutoDrive.MAX_BUNKERSILO_LENGTH + AutoDrive.getSetting("maxTriggerDistance")) and AutoDrive.isVehicleInBunkerSiloArea(self.vehicle) then
+            if self.distanceToTarget < (AutoDrive.MAX_BUNKERSILO_LENGTH + AutoDrive.getMaxTriggerDistance(self.vehicle)) and AutoDrive.isVehicleInBunkerSiloArea(self.vehicle) then
                 -- vehicle enters drive through bunker silo
                 self.speedLimit = math.min(12, self.speedLimit)
                 maxSpeedDiff = 3
             else
-                local isInRangeToLoadUnloadTarget = AutoDrive.isInRangeToLoadUnloadTarget(self.vehicle) and self.distanceToTarget <= AutoDrive.getSetting("maxTriggerDistance")
+                local isInRangeToLoadUnloadTarget = AutoDrive.isInRangeToLoadUnloadTarget(self.vehicle) and self.distanceToTarget <= AutoDrive.getMaxTriggerDistance(self.vehicle)
                 if isInRangeToLoadUnloadTarget == true then
                     self.speedLimit = math.min(5, self.speedLimit)
                 end

--- a/scripts/Modules/TrailerModule.lua
+++ b/scripts/Modules/TrailerModule.lua
@@ -448,7 +448,7 @@ end
 
 function ADTrailerModule:updateUnload(dt)
     AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_TRAILERINFO, "ADTrailerModule:updateUnload ")
-    AutoDrive.setAugerPipeOpen(self.trailers,  AutoDrive.getDistanceToUnloadPosition(self.vehicle) <= AutoDrive.getSetting("maxTriggerDistance"))
+    AutoDrive.setAugerPipeOpen(self.trailers,  AutoDrive.getDistanceToUnloadPosition(self.vehicle) <= AutoDrive.getMaxTriggerDistance(self.vehicle))
 
     if not self.isUnloading and not (self.lastUnloadRotateTrigger) then
         AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_TRAILERINFO, "ADTrailerModule:updateUnload not self.isUnloading")
@@ -604,7 +604,7 @@ function ADTrailerModule:lookForPossibleUnloadTrigger(trailer)
     -- local distanceToTarget = AutoDrive.getDistanceToUnloadPosition(self.vehicle)
     local distanceToTarget = AutoDrive.getDistanceToUnloadPosition(trailer)
 
-    if distanceToTarget < AutoDrive.getSetting("maxTriggerDistance") then
+    if distanceToTarget < AutoDrive.getMaxTriggerDistance(self.vehicle) then
         -- silo trigger - found by CanDischargeToObject, no need to loop through all triggers
         if trailer.getCanDischargeToObject and trailer.getCurrentDischargeNode and trailer.getDischargeState then
             if trailer:getCanDischargeToObject(trailer:getCurrentDischargeNode()) then

--- a/scripts/Settings.lua
+++ b/scripts/Settings.lua
@@ -740,6 +740,18 @@ AutoDrive.settings.maxTriggerDistance = {
     isVehicleSpecific = false
 }
 
+AutoDrive.settings.maxTriggerDistanceVehicle = {
+    values = {0, 10, 25, 50, 100, 200},
+    texts = {"gui_ad_useGlobalSetting", "10 m", "25 m", "50 m", "100 m", "200 m"},
+    default = 0,
+    current = 0,
+    text = "gui_ad_maxTriggerDistance",
+    tooltip = "gui_ad_maxTriggerDistance_tooltip",
+    translate = true,
+    isVehicleSpecific = true,
+}
+
+
 AutoDrive.settings.useBeaconLights = {
     values = {false, true},
     texts = {"gui_ad_no", "gui_ad_yes"},
@@ -1161,4 +1173,15 @@ function AutoDrive.readVehicleSettingsFromXML(vehicle, xmlFile, key)
             end
         end
     end
+end
+
+function AutoDrive.getMaxTriggerDistance(vehicle)
+    -- the max-trigger-distance can be set globally and per-vehicle.
+    -- a per-vehicle setting of 0 means "use global value"
+    -- NB: this might not be the best place for this function
+    local distance = AutoDrive.getSetting("maxTriggerDistanceVehicle", vehicle)
+    if distance == 0 then
+        distance = AutoDrive.getSetting("maxTriggerDistance")
+    end
+    return distance
 end

--- a/scripts/Utils/TrailerUtil.lua
+++ b/scripts/Utils/TrailerUtil.lua
@@ -713,7 +713,7 @@ function AutoDrive.getTriggerAndTrailerPairs(vehicle, dt)
     local trailerTriggerPairs = {}
     -- local trailers, _ = AutoDrive.getTrailersOf(vehicle, false)
     local trailers, _ = AutoDrive.getAllUnits(vehicle)
-    local maxTriggerDistance = AutoDrive.getSetting("maxTriggerDistance")
+    local maxTriggerDistance = AutoDrive.getMaxTriggerDistance(vehicle)
     for _, trailer in ipairs(trailers) do
         if trailer.getFillUnits ~= nil then
             local fillUnits = trailer:getFillUnits()
@@ -918,9 +918,9 @@ function AutoDrive.isInRangeToLoadUnloadTarget(vehicle)
         else
             ret =
                     (
-                        ((rootVehicle.ad.stateModule:getCurrentMode():shouldLoadOnTrigger() == true) and AutoDrive.getDistanceToTargetPosition(vehicle) <= AutoDrive.getSetting("maxTriggerDistance"))
+                        ((rootVehicle.ad.stateModule:getCurrentMode():shouldLoadOnTrigger() == true) and AutoDrive.getDistanceToTargetPosition(vehicle) <= AutoDrive.getMaxTriggerDistance(vehicle))
                         or
-                        ((rootVehicle.ad.stateModule:getCurrentMode():shouldUnloadAtTrigger() == true) and AutoDrive.getDistanceToUnloadPosition(vehicle) <= AutoDrive.getSetting("maxTriggerDistance"))
+                        ((rootVehicle.ad.stateModule:getCurrentMode():shouldUnloadAtTrigger() == true) and AutoDrive.getDistanceToUnloadPosition(vehicle) <= AutoDrive.getMaxTriggerDistance(vehicle))
                     )
         end
     end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 Modos: Sem alteração de destino / apenas destino de Coleta / apenas destino de Entrega / destino de Coleta e Entrega na pasta são ciclados (não com pasta padrão) (considerado apenas se as pastas de uso estiverem ativas)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Maximo disância do trigger" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distância do destino em que os triggers são detectados e ativados." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Luzes piscantes" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Sim - Use luzes de sinalização automáticas fora dos campos / Não - as luzes de sinalização não serão ligadas ou desligadas automaticamente" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Luz de aviso ao carregar/descarregar" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4种模式:不更改目标/仅装载目标/仅卸载目标/文件夹中的装载和卸载目标循环（不使用默认文件夹）（仅在使用文件夹处于活动状态时才考虑）" />
 		<text name="gui_ad_maxTriggerDistance"					text="最大触发距离" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="检测和激活目标触发器的距离。" />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="信标灯" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="是 - 在田地外自动使用信标灯/否 - 信标灯不会自动打开或关闭" />
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_distributeToFolder_tooltip"			text="Všechny cíle v jednom adresáři budou použity pro vykládku" />
 		<text name="gui_ad_maxTriggerDistance"					text="Rozsah detekce triggerů" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Rozsah, ve kterém jsou detekovány aktivní triggery (např. osivo a hnojivo)." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Zapnout maják" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Použití majáku na silnici" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -172,6 +172,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 Modi: kein Wechsel der Ziele / nur Beladeziele / nur Entladeziele / Be- und Entladeziele im Ordner rotierend wechseln (nicht für Standard-Ordner) (und nur wenn Ordner verwenden aktiv)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Maximaler Siloabstand" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Bis zu dieser Entfernung zum Zielpunkt wird beladen/entladen bei erkanntem Trigger." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Rundumleuchten" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Ja - Außerhalb des Felds automatisch eingeschaltet / Nein - Rundumleuchten werden nicht automatisch ein- oder ausgeschaltet" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Arbeitslicht beim Be- und Entladen" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 Modes: No change of targets / only Pickup Targets / only Deliver Targets / Pickup and Deliver Targets in folder are cycled (not with default folder) (only considered if use folders is active)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Maximum trigger distance" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distance to target at which triggers are detected and activated." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Beacon lights" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Yes - Use beacon lights automatic outside of fields / No - beacon lights will not be turned on or off automatically" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -164,6 +164,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 modos: Sin cambio de objetivos/Solo recoger de objetivos/Solo entregar a objetivos/Recoger y entregar a objetivos dentro de la carpeta en bucle (no funciona con la carpeta por defecto) (solo funciona si se activa la opción de usar carpetas)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Distancia máxima al desencadenante" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distancia a la que se detectan y activan los desencadenantes (por ejemplo, al llegar a un punto de descarga)." />		
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Luces rotativas" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Sí: Usa luces rotativas automáticas fuera de los campos/No: Las luces rotativas no se encenderán ni apagarán automáticamente" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Luz de trabajo al Cargar/Descargar" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 Modes: Aucune destination / uniquement les points de collecte / uniquement les points de livraison / les points de collecte et livraison sont choisis alternativement depuis un dossier (désactivé dans le dossier par défaut). Possible uniquement si gestion par dossier activée)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Distance maximum du déclencheur" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distance de détection du déclencheur au point de destination pour le chargement/déchargement." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Gyrophares" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Oui - ils seront allumés automatiquement en dehors des champs / Non - pas d'allumage ou extinction automatique" />
 		<text name="gui_ad_worklightsWhenLoading"				text="Feux de travail pendant le chargement/déchargement" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -164,6 +164,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"			    text="4 Modes: A célok nem változnak / csak a felvételi célok / csak a célok kézbesítése / az átvétel és a célok kézbesítése a mappában ciklusosak (nem az alapértelmezett mappával) (csak akkor vehető figyelembe, ha a mappák használata aktív)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Maximális kirakodási távolság" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="A célponttól e távolságig a kirakodás felismerése esetén be- és kirakodás történik" />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Jelző lámpa" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Használjon jelzőfényeket az úton." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -166,6 +166,7 @@
         <text name="gui_ad_distributeToFolder_tooltip"      	text="Tutte le destinazioni nella stessa cartella verranno ruotate come destinazioni di scarico." />
         <text name="gui_ad_maxTriggerDistance"          	text="Distanza massima dal trigger" />
         <text name="gui_ad_maxTriggerDistance_tooltip"      	text="Distanza dall'obiettivo in cui i trigger vengono rilevati e attivati." />
+        <text name="gui_ad_useGlobalSetting"			    text="Use global setting" />
         <text name="gui_ad_useBeaconLights"             	text="Accendi Fari" />
         <text name="gui_ad_useBeaconLights_tooltip"         	text="Usa i fari sulla strada." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Faro da lavoro durante carico/scarico" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -168,6 +168,7 @@
 		<text name="gui_ad_distributeToFolder_tooltip"			text="Alle bestemmingen in dezelfde map worden geroteerd als aflever bestemming." />
 		<text name="gui_ad_maxTriggerDistance"					text="Maximale trigger afstand" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Afstand tot aflever/ophaal bestemming waar de trigger wordt gevonden en geactiveerd." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Zwaailichten" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Gebruik zwaailampen buiten de velden." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -167,6 +167,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"				text="4 Tryby: Bez zmiany celów / tylko cele odbioru / tylko cele dostarczania / Cele odbioru i dostarczania w folderze są kolejno przełączane (nie w folderze domyślnym) (działa tylko przy wykorzystywaniu folderów)" />
 		<text name="gui_ad_maxTriggerDistance"					text="Maksymalna odległość do triggerów" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Odległość do celów, przy której są wykrywane i aktywowane triggery." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Światła ostrzegawcze" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Używaj świateł ostrzegawczych na drodze." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_distributeToFolder_tooltip"			text="Todos os destinos na mesma pasta serão girados como destinos de descarregamento." />
 		<text name="gui_ad_maxTriggerDistance"					text="Distância máxima de gatilho" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Distância ao alvo em que os gatilhos são detectados e ativados." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Pirilampos" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Use pirilampos na estrada." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -166,6 +166,7 @@
 		<text name="gui_ad_rotateTargets_tooltip"				text="4 режима: не менять локации/ только локации Загрузок/ только локации Доставок/ менять циклически в папке локации Загрузок и Доставок (не для стандартных папок) (учитывается при активации 'Использовать папки')." />
 		<text name="gui_ad_maxTriggerDistance"					text="Макс. расстояние триггера" />
 		<text name="gui_ad_maxTriggerDistance_tooltip"			text="Расстояние до локации, на котором обнаруживаются и активируются триггеры." />
+		<text name="gui_ad_useGlobalSetting"					text="Use global setting" />
 		<text name="gui_ad_useBeaconLights"						text="Маячок" />
 		<text name="gui_ad_useBeaconLights_tooltip"				text="Да - использовать автоматические сигнальные огни за пределами полей / Нет - сигнальные огни не будут включаться или выключаться автоматически." />
 		<text name="gui_ad_worklightsWhenLoading"				text="Рабочий свет при загрузке/разгрузке" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -164,6 +164,7 @@
         <text name="gui_ad_rotateTargets_tooltip"                                                           text="4 Mod: Hedeflerde değişiklik yok / yalnızca Toplama Hedefleri / yalnızca Hedefleri Teslim Et / Klasördeki Alım ve Teslim Hedefleri döngü halinde (varsayılan klasörle değil) (yalnızca klasörleri kullan etkinse dikkate alınır)"  />
         <text name="gui_ad_maxTriggerDistance"                                                              text="Maksimum tetik mesafesi"  />
         <text name="gui_ad_maxTriggerDistance_tooltip"                                                      text="Tetikleyicilerin algılandığı ve etkinleştirildiği hedefe olan mesafe."  />
+        <text name="gui_ad_useGlobalSetting"					                                            text="Use global setting" />
         <text name="gui_ad_useBeaconLights"                                                                 text="Uyarı ışıkları"  />
         <text name="gui_ad_useBeaconLights_tooltip"                                                         text="Evet - Alanların dışında otomatik olarak uyarı ışıkları kullan / Hayır - uyarı ışıkları otomatik olarak açılmayacak veya kapanmayacak"  />
 		<text name="gui_ad_worklightsWhenLoading"				text="Worklight when Loading / Unloading" />


### PR DESCRIPTION
- Added a Max Trigger Distance setting to the vehicle settings
- Identical values to the global settings, except for a "Use global setting" entry (default)
- Added a getMaxTriggerDistance to settings.lua, which picks the right value
- Replaced all instances of `getSetting("maxTriggerDistance")` with a call to that function