### PR TITLE
move waypoints outside map boundaries

### DIFF
--- a/scripts/Utils/DevFuncs.lua
+++ b/scripts/Utils/DevFuncs.lua
@@ -47,6 +47,16 @@ function AutoDrive.devAction(vehicle)
     else
         Logging.info("[AD] AutoDrive.devAction vehicle %s", tostring(vehicle))
     end
+
+    if vehicle ~= nil and g_currentMission.mapWidth and AutoDrive.getDebugChannelIsSet(AutoDrive.DC_ROADNETWORKINFO) and AutoDrive.isInExtendedEditorMode() then
+        local x, y, z = getWorldTranslation(vehicle.rootNode)
+
+        for _, wp in pairs(ADGraphManager:getWayPoints()) do
+            if math.abs(wp.x) >= g_currentMission.mapWidth/2 or math.abs(wp.z) >= g_currentMission.mapHeight/2 then
+                ADGraphManager:moveWayPoint(wp.id, x, y, z, wp.flags)
+            end
+        end
+    end
     AutoDrive.devPrintDebugQueue(vehicle)
 end
 


### PR DESCRIPTION
singleplayer, enter vehicle, activate edit mode, locate vehicle where waypoints are some meters away, activate debug road network, invoke developer action waypoints outside map boundaries will be moved to vehicle position